### PR TITLE
flatten delimiter bug fix (GH-6)

### DIFF
--- a/cherrypicker/__about__.py
+++ b/cherrypicker/__about__.py
@@ -1,6 +1,6 @@
 __author__ = "big-o"
 __author_email__ = "big-o@users.noreply.github.com"
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __release__ = __version__
 __name__ = "cherrypicker"
 __title__ = "CherryPicker"

--- a/cherrypicker/__init__.py
+++ b/cherrypicker/__init__.py
@@ -1,3 +1,3 @@
-from .traversable import *
 from .leaf import *
 from .picker import *
+from .traversable import *

--- a/cherrypicker/leaf.py
+++ b/cherrypicker/leaf.py
@@ -1,9 +1,9 @@
 from __future__ import division
 
-from .exceptions import LeafError
-from .picker import CherryPicker
 from typing import Any
 
+from .exceptions import LeafError
+from .picker import CherryPicker
 
 __all__ = ("CherryPickerLeaf",)
 

--- a/cherrypicker/picker.py
+++ b/cherrypicker/picker.py
@@ -1,9 +1,9 @@
 from __future__ import division
 
 from collections.abc import Iterable, Mapping
-from joblib import effective_n_jobs
 from typing import Any, Callable, List, NoReturn, Optional, Tuple, Union
 
+from joblib import effective_n_jobs
 
 __all__ = ("CherryPicker",)
 

--- a/cherrypicker/util.py
+++ b/cherrypicker/util.py
@@ -1,7 +1,6 @@
 import collections.abc
 from typing import Any, Generator
 
-
 __all__ = ("OrderedSet",)
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,13 +18,13 @@ import sys
 sys.path.insert(0, os.path.abspath("../../"))
 
 from cherrypicker.__about__ import (
-    __name__,
-    __title__,
-    __version__,
     __author__,
     __author_email__,
-    __release__,
     __description__,
+    __name__,
+    __release__,
+    __title__,
+    __version__,
 )
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -96,9 +96,10 @@ custom functions. Read all about them in the :doc:`filter` documentation.
 Of course, it would be nice if we could extract data in the example above from
 both the base level and the ``info`` sub-level of each item and put them into a
 flat table, ready to load into your favourite data analysis package. We can do
-this in :mod:`cherrypicker` with :meth:`cherrypicker.CherryPickerMapping.flatten`.
-Let's say that each item in our data list has a city name and a list of average
-low/high temperatures for each month of the year:
+this conveniently in :mod:`cherrypicker` with the ``flat`` property of our picker
+which gives us a flattened view of the data. Let's say that each item in our data
+list has a city name and a list of average low/high temperatures for each month of the
+year:
 
 .. code-block:: python
 
@@ -132,17 +133,30 @@ monthly temperatures alongside each other:
 
 .. code-block:: python
 
-    >>> picker.flatten(
+    >>> picker.flat(
     ...     monthlyAvg_0_high=lambda tmp: tmp > 30
     ... )['city', 'monthlyAvg_0_high'].get()
     [['Bangkok', 33], ['Brasilia', 31], ['Ho Chi Minh City', 33], ...]
 
 .. code-block:: python
 
-    >>> picker.flatten(
+    >>> picker.flat(
     ...     monthlyAvg_0_high=lambda tmp: tmp < 0
     ... )['city', 'monthlyAvg_0_high'].get()
     [['Calgary', -1], ['Montreal', -4], ['Moscow', -4], ...]
+
+If you would like to customise the flattening behaviour, use the
+:meth:`cherrypicker.CherryPickerMapping.flatten` method instead:
+
+.. code-block:: python
+
+    >>> picker.flat[0].get()
+    {'id': 1, 'city': 'Amsterdam', 'country': 'Netherlands', 'monthlyAvg_0_high': 7, ...}
+
+.. code-block:: python
+
+    >>> picker.flatten(delim='.')[0].get()
+    {'id': 1, 'city': 'Amsterdam', 'country': 'Netherlands', 'monthlyAvg.0.high': 7, ...}
 
 One final point to note is that :mod:`cherrypicker` understands data by looking
 at its *interfaces* rather than its *types*. This means that it isn't just

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ coverage
 pytest
 pytest-black
 pytest-cov
+pytest-sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 addopts = -ra --black --cov=cherrypicker --cov-report=term
 
 [tox:tox]
-envlist = clean,py37,py38
+envlist = clean,py37,py38,py39
 
 [testenv]
 usedevelop = True

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 # Always prefer setuptools over distutils
-from setuptools import setup, find_packages
-import os
 import importlib.util
+import os
 
+from setuptools import find_packages, setup
 
 about = None
 for root, dirs, files in os.walk("."):

--- a/tests/test_picker.py
+++ b/tests/test_picker.py
@@ -1,9 +1,11 @@
-from cherrypicker import CherryPicker
-from cherrypicker.exceptions import *
 import json
 import os
-import pytest
 import re
+
+import pytest
+
+from cherrypicker import CherryPicker
+from cherrypicker.exceptions import *
 
 
 def abs_path(path):
@@ -67,10 +69,10 @@ def run_flatten_tests(n_jobs=None):
 
     fpicker = CherryPicker(first, n_jobs=n_jobs)
     picker = CherryPicker(data, n_jobs=n_jobs)
-    assert list(fpicker.flatten.keys()) == flat_keys
+    assert list(fpicker.flat.keys()) == flat_keys
     assert list(fpicker.flatten().keys()) == flat_keys
 
-    assert list(picker.flatten[0].keys()) == flat_keys
+    assert list(picker.flat[0].keys()) == flat_keys
     assert list(picker.flatten()[0].keys()) == flat_keys
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
-from cherrypicker.util import *
-
 import pytest
+
+from cherrypicker.util import *
 
 
 def test_orderedset():


### PR DESCRIPTION
Changed `flatten` property to a method that excepts arguments to fix #6 . Created a new property called `flat` that just applies `flatten()` with default args.

This is a breaking change, but the userbase is small and I'd rather have a more intuitive interface going forward, so meh.